### PR TITLE
building for ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,20 @@ dist: trusty
 osx_image: xcode7
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
       wget https://github.com/glfw/glfw/releases/download/3.1.1/glfw-3.1.1.zip;
       sudo apt-get update;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew uninstall xctool;
-      brew install xctool --HEAD;
-      brew install homebrew/versions/glfw3;
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      brew update;
+      brew install glfw3;
       brew install libusb;
+      brew upgrade cmake; 
     fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get install -qq build-essential xorg-dev libglu1-mesa-dev libglew-dev libglm-dev;
       sudo apt-get install -qq cmake;
       sudo apt-get install -qq libusb-1.0-0-dev ;
@@ -37,10 +37,13 @@ install:
       cd ..;
     fi
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       uname -a;
       make;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      xctool -workspace librealsense.xc/librealsense.xcworkspace -scheme librealsense ONLY_ACTIVE_ARCH=NO;
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      export PATH="/usr/local/bin:$PATH";
+      cmake .. -DBUILD_EXAMPLES=true -DBUILD_WITH_OPENMP=false -DHWM_OVER_XU=false -DCHECK_FOR_UPDATES=true;
+      cmake --build . --config $LRS_BUILD_CONFIG -- -j4;
+      ls;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,8 @@ before_install:
       sudo apt-get update;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      brew uninstall xctool;
-      brew install xctool --HEAD;
-      brew install homebrew/versions/glfw3;
+      brew update;
+      brew install glfw3;
       brew install libusb;
     fi
 
@@ -42,7 +41,7 @@ script:
       make;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      sudo cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=ON;
+      sudo cmake -DBUILD_SHARED_LIBS=ON;
       sudo make;
       sudo make install;
       cd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,12 @@ dist: trusty
 osx_image: xcode7
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test;
       wget https://github.com/glfw/glfw/releases/download/3.1.1/glfw-3.1.1.zip;
       sudo apt-get update;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew uninstall xctool;
       brew install xctool --HEAD;
       brew install homebrew/versions/glfw3;
@@ -22,7 +22,7 @@ before_install:
     fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       sudo apt-get install -qq build-essential xorg-dev libglu1-mesa-dev libglew-dev libglm-dev;
       sudo apt-get install -qq cmake;
       sudo apt-get install -qq libusb-1.0-0-dev ;
@@ -37,10 +37,13 @@ install:
       cd ..;
     fi
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then
       uname -a;
       make;
     fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      xctool -workspace librealsense.xc/librealsense.xcworkspace -scheme librealsense ONLY_ACTIVE_ARCH=NO;
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      sudo cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=ON;
+      sudo make;
+      sudo make install;
+      cd ..;
     fi

--- a/CMakeList.txt
+++ b/CMakeList.txt
@@ -1,0 +1,18 @@
+# License: Apache 2.0. See LICENSE file in root directory.
+# Copyright(c) 2019 Intel Corporation. All Rights Reserved.
+cmake_minimum_required(VERSION 3.1.0)
+
+project(hello_librealsense2)
+
+# Find librealsense2 installed package
+find_package(realsense2 REQUIRED)
+
+# Enable C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
+
+# Add the application sources to the target
+add_executable(${PROJECT_NAME} hello_librealsense2.cpp)
+
+# Link librealsense2 to the target
+target_link_libraries(${PROJECT_NAME} ${realsense2_LIBRARY})

--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -22,6 +22,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <linux/usb/video.h>


### PR DESCRIPTION
Ubuntu 20.04 needs `minor` macro and did not find with the current header files. This PR introduce <sys/sysmacros.h> to help compiler to find `minor` macro.