### PR TITLE
fix build for ubuntu 20.04

### DIFF
--- a/src/uvc-v4l2.cpp
+++ b/src/uvc-v4l2.cpp
@@ -28,6 +28,7 @@
 #include <limits.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/mman.h>
 #include <sys/ioctl.h>
 #include <linux/usb/video.h>


### PR DESCRIPTION
Ubuntu 20.04 needs minor macro and did not find with the current header files. This PR introduce <sys/sysmacros.h> to help compiler to find minor macro.